### PR TITLE
Rename task to system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "shred"
 version = "0.1.0"
 authors = ["torkleyy"]
 description = """
-Dispatches tasks in parallel which need read access to some resources,
+Dispatches systems in parallel which need read access to some resources,
 and write access to others.
 """
 readme = "README.md"
 documentation = "https://docs.rs/shred"
 repository = "https://github.com/torkleyy/shred"
-keywords = ["parallel", "tasks", "resources", "ecs"]
+keywords = ["parallel", "systems", "resources", "ecs"]
 categories = ["concurrency"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [dl]: https://docs.rs/shred/
 
 This library allows to dispatch
-tasks, which can have interdependencies,
+systems, which can have interdependencies,
 shared and exclusive resource access, in parallel.
 
 ## Usage
@@ -22,9 +22,9 @@ shared and exclusive resource access, in parallel.
 ```rust
 extern crate shred;
 #[macro_use]
-extern crate shred_derive; // for `#[derive(TaskData)]`
+extern crate shred_derive; // for `#[derive(SystemData)]`
 
-use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, Task};
+use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, System};
 
 #[derive(Debug)]
 struct ResA;
@@ -36,9 +36,9 @@ struct ResB;
 
 impl Resource for ResB {}
 
-/// Every task has a predefined
-/// task data.
-#[derive(TaskData)]
+/// Every system has a predefined
+/// system data.
+#[derive(SystemData)]
 struct PrintData<'a> {
     /// `Fetch` means it reads from
     /// that data
@@ -48,10 +48,10 @@ struct PrintData<'a> {
     b: FetchMut<'a, ResB>,
 }
 
-struct PrintTask;
+struct PrintSystem;
 
-impl<'a> Task<'a> for PrintTask {
-    type TaskData = PrintData<'a>;
+impl<'a> System<'a> for PrintSystem {
+    type SystemData = PrintData<'a>;
 
     fn work(&mut self, bundle: PrintData<'a>) {
         println!("{:?}", &*bundle.a);
@@ -65,7 +65,7 @@ impl<'a> Task<'a> for PrintTask {
 fn main() {
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add(PrintTask, "print", &[]) // Adds a task "print" without dependencies
+        .add(PrintSystem, "print", &[]) // Adds a system "print" without dependencies
         .finish();
     resources.add(ResA, ());
     resources.add(ResB, ());

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -71,7 +71,7 @@ const NUM_COMPONENTS: usize = 200;
 
 // --------------
 
-#[derive(TaskData)]
+#[derive(SystemData)]
 struct SpringForceData<'a> {
     pos: Fetch<'a, PosStorage>,
     spring: Fetch<'a, SpringStorage>,
@@ -81,8 +81,8 @@ struct SpringForceData<'a> {
 
 struct SpringForce;
 
-impl<'a> Task<'a> for SpringForce {
-    type TaskData = SpringForceData<'a>;
+impl<'a> System<'a> for SpringForce {
+    type SystemData = SpringForceData<'a>;
 
     fn work(&mut self, mut data: SpringForceData) {
         for elem in 0..NUM_COMPONENTS {
@@ -103,7 +103,7 @@ impl<'a> Task<'a> for SpringForce {
     }
 }
 
-#[derive(TaskData)]
+#[derive(SystemData)]
 struct IntegrationData<'a> {
     force: Fetch<'a, ForceStorage>,
     mass: Fetch<'a, MassStorage>,
@@ -113,10 +113,10 @@ struct IntegrationData<'a> {
     time: Fetch<'a, DeltaTime>,
 }
 
-struct IntegrationTask;
+struct IntegrationSystem;
 
-impl<'a> Task<'a> for IntegrationTask {
-    type TaskData = IntegrationData<'a>;
+impl<'a> System<'a> for IntegrationSystem {
+    type SystemData = IntegrationData<'a>;
 
     fn work(&mut self, mut data: IntegrationData) {
         for elem in 0..NUM_COMPONENTS {
@@ -144,15 +144,15 @@ impl<'a> Task<'a> for IntegrationTask {
     }
 }
 
-#[derive(TaskData)]
+#[derive(SystemData)]
 struct ClearForceAccumData<'a> {
     force: FetchMut<'a, ForceStorage>,
 }
 
 struct ClearForceAccum;
 
-impl<'a> Task<'a> for ClearForceAccum {
-    type TaskData = ClearForceAccumData<'a>;
+impl<'a> System<'a> for ClearForceAccum {
+    type SystemData = ClearForceAccumData<'a>;
 
     fn work(&mut self, mut data: ClearForceAccumData) {
         for elem in 0..NUM_COMPONENTS {
@@ -169,7 +169,7 @@ impl<'a> Task<'a> for ClearForceAccum {
 fn basic(b: &mut Bencher) {
     let mut dispatcher = DispatcherBuilder::new()
         .add(SpringForce, "spring", &[])
-        .add(IntegrationTask, "integration", &[])
+        .add(IntegrationSystem, "integration", &[])
         .add(ClearForceAccum, "clear_force", &["integration"]) // clear_force is executed after
                                                                // the integration
         .finish();

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, Task};
+use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, System};
 
 #[derive(Debug)]
 struct ResA;
@@ -14,16 +14,16 @@ struct ResB;
 
 impl Resource for ResB {}
 
-#[derive(TaskData)]
+#[derive(SystemData)]
 struct Data<'a> {
     a: Fetch<'a, ResA>,
     b: FetchMut<'a, ResB>,
 }
 
-struct EmptyTask;
+struct EmptySystem;
 
-impl<'a> Task<'a> for EmptyTask {
-    type TaskData = Data<'a>;
+impl<'a> System<'a> for EmptySystem {
+    type SystemData = Data<'a>;
 
     fn work(&mut self, bundle: Data<'a>) {
         println!("{:?}", &*bundle.a);
@@ -35,7 +35,7 @@ impl<'a> Task<'a> for EmptyTask {
 fn main() {
     let mut resources = Resources::new();
     let mut dispatcher = DispatcherBuilder::new()
-        .add(EmptyTask, "empty", &[])
+        .add(EmptySystem, "empty", &[])
         .finish();
     resources.add(ResA, ());
     resources.add(ResB, ());

--- a/examples/custom_bundle.rs
+++ b/examples/custom_bundle.rs
@@ -2,7 +2,7 @@ extern crate shred;
 
 use std::any::TypeId;
 
-use shred::{Fetch, FetchMut, Resource, ResourceId, Resources, TaskData};
+use shred::{Fetch, FetchMut, Resource, ResourceId, Resources, SystemData};
 
 #[derive(Debug)]
 struct ResA;
@@ -19,7 +19,7 @@ struct ExampleBundle<'a> {
     b: FetchMut<'a, ResB>,
 }
 
-impl<'a> TaskData<'a> for ExampleBundle<'a> {
+impl<'a> SystemData<'a> for ExampleBundle<'a> {
     fn fetch(res: &'a Resources) -> Self {
         ExampleBundle {
             a: unsafe { res.fetch(0) },

--- a/examples/derive_bundle.rs
+++ b/examples/derive_bundle.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{Fetch, FetchMut, Resource, Resources, TaskData};
+use shred::{Fetch, FetchMut, Resource, Resources, SystemData};
 
 #[derive(Debug)]
 struct ResA;
@@ -14,7 +14,7 @@ struct ResB;
 
 impl Resource for ResB {}
 
-#[derive(TaskData)]
+#[derive(SystemData)]
 pub struct AutoBundle<'a> {
     a: Fetch<'a, ResA>,
     b: FetchMut<'a, ResB>,

--- a/shred-derive/Cargo.toml
+++ b/shred-derive/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["torkleyy"]
 description = "Custom derive for shred"
 documentation = "https://docs.rs/shred_derive"
 repository = "https://github.com/torkleyy/shred/shred-derive"
-keywords = ["parallel", "tasks", "resources", "ecs", "derive"]
+keywords = ["parallel", "systems", "resources", "ecs", "derive"]
 license = "MIT/Apache-2.0"
 
 [dependencies]

--- a/shred-derive/src/lib.rs
+++ b/shred-derive/src/lib.rs
@@ -10,18 +10,18 @@ use syn::{Body, Field, Ident, MacroInput, VariantData};
 use quote::Tokens;
 
 /// Used to `#[derive]` the trait
-/// `TaskData`.
-#[proc_macro_derive(TaskData)]
-pub fn task_data(input: TokenStream) -> TokenStream {
+/// `SystemData`.
+#[proc_macro_derive(SystemData)]
+pub fn system_data(input: TokenStream) -> TokenStream {
     let s = input.to_string();
     let ast = syn::parse_macro_input(&s).unwrap();
 
-    let gen = impl_task_data(&ast);
+    let gen = impl_system_data(&ast);
 
     gen.parse().expect("Invalid")
 }
 
-fn impl_task_data(ast: &MacroInput) -> Tokens {
+fn impl_system_data(ast: &MacroInput) -> Tokens {
     let name = &ast.ident;
     let fields = get_fields(ast);
 
@@ -31,7 +31,7 @@ fn impl_task_data(ast: &MacroInput) -> Tokens {
     let writes = collect_field_ty_params(fields, "FetchMut");
 
     quote! {
-        impl<'a> ::shred::TaskData<'a> for #name<'a> {
+        impl<'a> ::shred::SystemData<'a> for #name<'a> {
             fn fetch(res: &'a ::shred::Resources) -> #name<'a> {
                 #name {
                     #( #identifiers: unsafe { res.#methods(()) }, )*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! **Sh**ared **re**source **d**ispatcher
 //!
 //! This library allows to dispatch
-//! tasks, which can have interdependencies,
+//! systems, which can have interdependencies,
 //! shared and exclusive resource access, in parallel.
 //!
 //! # Examples
@@ -11,7 +11,7 @@
 //! #[macro_use]
 //! extern crate shred_derive;
 //!
-//! use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, Task};
+//! use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, System};
 //!
 //! #[derive(Debug)]
 //! struct ResA;
@@ -23,16 +23,16 @@
 //!
 //! impl Resource for ResB {}
 //!
-//! #[derive(TaskData)]
+//! #[derive(SystemData)]
 //! struct Data<'a> {
 //!     a: Fetch<'a, ResA>,
 //!     b: FetchMut<'a, ResB>,
 //! }
 //!
-//! struct EmptyTask;
+//! struct EmptySystem;
 //!
-//! impl<'a> Task<'a> for EmptyTask {
-//!     type TaskData = Data<'a>;
+//! impl<'a> System<'a> for EmptySystem {
+//!     type SystemData = Data<'a>;
 //!
 //!     fn work(&mut self, bundle: Data<'a>) {
 //!         println!("{:?}", &*bundle.a);
@@ -44,7 +44,7 @@
 //! fn main() {
 //!     let mut resources = Resources::new();
 //!     let mut dispatcher = DispatcherBuilder::new()
-//!         .add(EmptyTask, "empty", &[])
+//!         .add(EmptySystem, "empty", &[])
 //!         .finish();
 //!     resources.add(ResA, ());
 //!     resources.add(ResB, ());
@@ -66,8 +66,8 @@ mod bitset;
 mod cell;
 mod dispatch;
 mod res;
-mod task;
+mod system;
 
 pub use dispatch::{Dispatcher, DispatcherBuilder};
 pub use res::{Fetch, FetchId, FetchIdMut, FetchMut, Resource, ResourceId, Resources};
-pub use task::{Task, TaskData};
+pub use system::{System, SystemData};

--- a/src/res.rs
+++ b/src/res.rs
@@ -172,7 +172,7 @@ impl Resources {
     /// Fetches the resource with the specified type `T`.
     /// The id is useful if you don't define your resources
     /// in Rust or you want a more dynamic resource handling.
-    /// By default, the `#[derive(TaskData)]` passes `()`
+    /// By default, the `#[derive(SystemData)]` passes `()`
     /// as id.
     ///
     /// # Safety

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,27 +1,27 @@
 use {ResourceId, Resources};
 
-/// A `Task`, executed with a
+/// A `System`, executed with a
 /// set of required [`Resource`]s.
 ///
 /// [`Resource`]: trait.Resource.html
-pub trait Task<'a> {
+pub trait System<'a> {
     /// The resource bundle required
-    /// to execute this task.
+    /// to execute this system.
     ///
     /// To create such a resource bundle,
-    /// simple derive `TaskData` for it.
-    type TaskData: TaskData<'a>;
+    /// simple derive `SystemData` for it.
+    type SystemData: SystemData<'a>;
 
-    /// Executes the task with the required task
+    /// Executes the system with the required system
     /// data.
-    fn work(&mut self, bundle: Self::TaskData);
+    fn work(&mut self, data: Self::SystemData);
 }
 
 /// A struct implementing
-/// task data indicates that it
+/// system data indicates that it
 /// bundles some resources which are
 /// required for the execution.
-pub trait TaskData<'a> {
+pub trait SystemData<'a> {
     /// Creates a new resource bundle
     /// by fetching the required resources
     /// from the [`Resources`] struct.


### PR DESCRIPTION
The name system is more appropriate because it is executed multiple times.