### PR TITLE
Replace System trait with functions

### DIFF
--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -2,7 +2,7 @@ extern crate shred;
 #[macro_use]
 extern crate shred_derive;
 
-use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, System};
+use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources};
 
 #[derive(Debug)]
 struct ResA;
@@ -20,25 +20,23 @@ struct Data<'a> {
     b: FetchMut<'a, ResB>,
 }
 
+#[derive(Clone)]
 struct EmptySystem;
 
-impl<'a> System<'a> for EmptySystem {
-    type SystemData = Data<'a>;
-
-    fn work(&mut self, bundle: Data<'a>) {
-        println!("{:?}", &*bundle.a);
-        println!("{:?}", &*bundle.b);
-    }
+fn work<'a>(_: &mut EmptySystem, bundle: Data<'a>) {
+    println!("{:?}", &*bundle.a);
+    println!("{:?}", &*bundle.b);
 }
 
 
 fn main() {
     let mut resources = Resources::new();
-    let mut dispatcher = DispatcherBuilder::new()
-        .add(EmptySystem, "empty", &[])
-        .finish();
     resources.add(ResA, ());
     resources.add(ResB, ());
+    
+    let mut dispatcher = DispatcherBuilder::new()
+        .add("empty", work, EmptySystem, &[])
+        .finish();
 
-    dispatcher.dispatch(&mut resources);
+    dispatcher.dispatch(&resources);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! #[macro_use]
 //! extern crate shred_derive;
 //!
-//! use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources, System};
+//! use shred::{DispatcherBuilder, Fetch, FetchMut, Resource, Resources};
 //!
 //! #[derive(Debug)]
 //! struct ResA;
@@ -31,20 +31,16 @@
 //!
 //! struct EmptySystem;
 //!
-//! impl<'a> System<'a> for EmptySystem {
-//!     type SystemData = Data<'a>;
-//!
-//!     fn work(&mut self, bundle: Data<'a>) {
-//!         println!("{:?}", &*bundle.a);
-//!         println!("{:?}", &*bundle.b);
-//!     }
+//! fn work<'a>(_: &mut EmptySystem, bundle: Data<'a>) {
+//!     println!("{:?}", &*bundle.a);
+//!     println!("{:?}", &*bundle.b);
 //! }
 //!
 //!
 //! fn main() {
 //!     let mut resources = Resources::new();
 //!     let mut dispatcher = DispatcherBuilder::new()
-//!         .add(EmptySystem, "empty", &[])
+//!         .add("empty", work, EmptySystem, &[])
 //!         .finish();
 //!     resources.add(ResA, ());
 //!     resources.add(ResB, ());
@@ -70,4 +66,4 @@ mod system;
 
 pub use dispatch::{Dispatcher, DispatcherBuilder};
 pub use res::{Fetch, FetchId, FetchIdMut, FetchMut, Resource, ResourceId, Resources};
-pub use system::{System, SystemData};
+pub use system::{SystemData};

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,21 +1,5 @@
 use {ResourceId, Resources};
 
-/// A `System`, executed with a
-/// set of required [`Resource`]s.
-///
-/// [`Resource`]: trait.Resource.html
-pub trait System<'a> {
-    /// The resource bundle required
-    /// to execute this system.
-    ///
-    /// To create such a resource bundle,
-    /// simple derive `SystemData` for it.
-    type SystemData: SystemData<'a>;
-
-    /// Executes the system with the required system
-    /// data.
-    fn work(&mut self, data: Self::SystemData);
-}
 
 /// A struct implementing
 /// system data indicates that it
@@ -64,3 +48,7 @@ pub trait SystemData<'a> {
     /// (otherwise it has no effect).
     unsafe fn writes() -> Vec<ResourceId>;
 }
+
+/// Helper trait for storing SystemDatas inside the Dispatcher.
+pub trait Helper { }
+impl<'a, T> Helper for T where T: SystemData<'a> { }


### PR DESCRIPTION
cc #7 

Splitting the current `exec` into two functions: `fetch` which will acquire the data bundle and `exec` which executes the worker function.
The main drawback is the introduction of more `Box` and the requirement of a `unsafe` block, wasn't able to remove this with `Any` due to `'static` restriction. (Helper helps!)

An new constraint is that `Resources` needs to outlive the `Dispatcher` but I think thats pretty minor..

