### PR TITLE
Remove the context type parameter

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,7 +6,6 @@ extern crate shred;
 extern crate shred_derive;
 extern crate test;
 
-use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 
 use cgmath::Vector3;
@@ -38,12 +37,8 @@ impl<T> IndexMut<usize> for VecStorage<T> {
     }
 }
 
-impl<T> Resource for VecStorage<T> where T: Debug + Send + Sync + 'static {}
-
 #[derive(Debug)]
 struct DeltaTime(f32);
-
-impl Resource for DeltaTime {}
 
 type Vec3 = Vector3<f32>;
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -84,10 +84,10 @@ struct SpringForceData<'a> {
 
 struct SpringForce;
 
-impl<'a, C> System<'a, C> for SpringForce {
+impl<'a> System<'a> for SpringForce {
     type SystemData = SpringForceData<'a>;
 
-    fn work(&mut self, mut data: SpringForceData, _: C) {
+    fn work(&mut self, mut data: SpringForceData) {
         for elem in 0..NUM_COMPONENTS {
             let pos = data.pos[elem].0;
             let spring: Spring = data.spring[elem];
@@ -118,10 +118,10 @@ struct IntegrationData<'a> {
 
 struct IntegrationSystem;
 
-impl<'a, C> System<'a, C> for IntegrationSystem {
+impl<'a> System<'a> for IntegrationSystem {
     type SystemData = IntegrationData<'a>;
 
-    fn work(&mut self, mut data: IntegrationData, _: C) {
+    fn work(&mut self, mut data: IntegrationData) {
         for elem in 0..NUM_COMPONENTS {
             let mass = data.mass[elem].0;
 
@@ -154,10 +154,10 @@ struct ClearForceAccumData<'a> {
 
 struct ClearForceAccum;
 
-impl<'a, C> System<'a, C> for ClearForceAccum {
+impl<'a> System<'a> for ClearForceAccum {
     type SystemData = ClearForceAccumData<'a>;
 
-    fn work(&mut self, mut data: ClearForceAccumData, _: C) {
+    fn work(&mut self, mut data: ClearForceAccumData) {
         for elem in 0..NUM_COMPONENTS {
             data.force[elem] = Force(Vec3 {
                                          x: 0.0,
@@ -197,5 +197,5 @@ fn basic(b: &mut Bencher) {
     res.add(force, ());
     res.add(spring, ());
 
-    b.iter(|| dispatcher.dispatch(&mut res, ()));
+    b.iter(|| dispatcher.dispatch(&mut res));
 }

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -10,13 +10,10 @@ struct ResB;
 
 struct PrintSystem;
 
-// Systems should be generic over the
-// context if possible, so it's easy
-// to introduce one.
-impl<'a, C> System<'a, C> for PrintSystem {
+impl<'a> System<'a> for PrintSystem {
     type SystemData = (Fetch<'a, ResA>, FetchMut<'a, ResB>);
 
-    fn work(&mut self, data: Self::SystemData, _: C) {
+    fn work(&mut self, data: Self::SystemData) {
         let (a, mut b) = data;
 
         println!("{:?}", &*a);
@@ -38,5 +35,5 @@ fn main() {
     // We can even pass a context,
     // but we don't need one here
     // so we pass `()`.
-    dispatcher.dispatch(&mut resources, ());
+    dispatcher.dispatch(&mut resources);
 }

--- a/examples/seq_dispatch.rs
+++ b/examples/seq_dispatch.rs
@@ -18,10 +18,10 @@ struct Data<'a> {
 
 struct EmptySystem;
 
-impl<'a, C> System<'a, C> for EmptySystem {
+impl<'a> System<'a> for EmptySystem {
     type SystemData = Data<'a>;
 
-    fn work(&mut self, bundle: Data<'a>, _: C) {
+    fn work(&mut self, bundle: Data<'a>) {
         println!("{:?}", &*bundle.a);
         println!("{:?}", &*bundle.b);
     }
@@ -35,5 +35,5 @@ fn main() {
     resources.add(ResA, ());
     resources.add(ResB, ());
 
-    dispatcher.dispatch_seq(&mut resources, ());
+    dispatcher.dispatch_seq(&mut resources);
 }

--- a/examples/thread_local.rs
+++ b/examples/thread_local.rs
@@ -18,10 +18,10 @@ struct Data<'a> {
 
 struct EmptySystem(*mut i8); // System is not thread-safe
 
-impl<'a, C> System<'a, C> for EmptySystem {
+impl<'a> System<'a> for EmptySystem {
     type SystemData = Data<'a>;
 
-    fn work(&mut self, bundle: Data<'a>, _: C) {
+    fn work(&mut self, bundle: Data<'a>) {
         println!("{:?}", &*bundle.a);
         println!("{:?}", &*bundle.b);
     }
@@ -37,5 +37,5 @@ fn main() {
     resources.add(ResA, ());
     resources.add(ResB, ());
 
-    dispatcher.dispatch(&mut resources, ());
+    dispatcher.dispatch(&mut resources);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,10 @@
 //!
 //! struct EmptySystem;
 //!
-//! impl<'a, C> System<'a, C> for EmptySystem {
+//! impl<'a> System<'a> for EmptySystem {
 //!     type SystemData = Data<'a>;
 //!
-//!     fn work(&mut self, bundle: Data<'a>, _: C) {
+//!     fn work(&mut self, bundle: Data<'a>) {
 //!         println!("{:?}", &*bundle.a);
 //!         println!("{:?}", &*bundle.b);
 //!     }
@@ -45,7 +45,7 @@
 //!     resources.add(ResA, ());
 //!     resources.add(ResB, ());
 //!
-//!     dispatcher.dispatch(&mut resources, ());
+//!     dispatcher.dispatch(&mut resources);
 //! }
 //! ```
 //!

--- a/src/system.rs
+++ b/src/system.rs
@@ -4,7 +4,7 @@ use {ResourceId, Resources};
 /// set of required [`Resource`]s.
 ///
 /// [`Resource`]: trait.Resource.html
-pub trait System<'a, C> {
+pub trait System<'a> {
     /// The resource bundle required
     /// to execute this system.
     ///
@@ -14,7 +14,7 @@ pub trait System<'a, C> {
 
     /// Executes the system with the required system
     /// data.
-    fn work(&mut self, data: Self::SystemData, context: C);
+    fn work(&mut self, data: Self::SystemData);
 }
 
 /// A struct implementing

--- a/tests/dispatch.rs
+++ b/tests/dispatch.rs
@@ -19,23 +19,23 @@ struct DummyDataMut<'a> {
 
 struct DummySys;
 
-impl<'a, C> System<'a, C> for DummySys {
+impl<'a> System<'a> for DummySys {
     type SystemData = DummyData<'a>;
 
-    fn work(&mut self, _data: Self::SystemData, _context: C) {}
+    fn work(&mut self, _data: Self::SystemData) {}
 }
 
 struct DummySysMut;
 
-impl<'a, C> System<'a, C> for DummySysMut {
+impl<'a> System<'a> for DummySysMut {
     type SystemData = DummyDataMut<'a>;
 
-    fn work(&mut self, _data: Self::SystemData, _context: C) {}
+    fn work(&mut self, _data: Self::SystemData) {}
 }
 
 #[test]
 fn dispatch_builder() {
-    DispatcherBuilder::<()>::new()
+    DispatcherBuilder::new()
         .add(DummySys, "a", &[])
         .add(DummySys, "b", &["a"])
         .add(DummySys, "c", &["a"])
@@ -45,7 +45,7 @@ fn dispatch_builder() {
 #[test]
 #[should_panic(expected = "No such system registered")]
 fn dispatch_builder_invalid() {
-    DispatcherBuilder::<()>::new()
+    DispatcherBuilder::new()
         .add(DummySys, "a", &[])
         .add(DummySys, "b", &["z"])
         .build();
@@ -56,12 +56,12 @@ fn dispatch_basic() {
     let mut res = Resources::new();
     res.add(Res, ());
 
-    let mut d: Dispatcher<_> = DispatcherBuilder::new()
+    let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySys, "a", &[])
         .add(DummySys, "b", &["a"])
         .build();
 
-    d.dispatch(&mut res, ());
+    d.dispatch(&mut res);
 }
 
 #[test]
@@ -69,12 +69,12 @@ fn dispatch_rw_block() {
     let mut res = Resources::new();
     res.add(Res, ());
 
-    let mut d: Dispatcher<_> = DispatcherBuilder::new()
+    let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySys, "a", &[])
         .add(DummySysMut, "b", &[])
         .build();
 
-    d.dispatch(&mut res, ());
+    d.dispatch(&mut res);
 }
 
 #[test]
@@ -82,12 +82,12 @@ fn dispatch_rw_block_rev() {
     let mut res = Resources::new();
     res.add(Res, ());
 
-    let mut d: Dispatcher<_> = DispatcherBuilder::new()
+    let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
         .add(DummySys, "b", &[])
         .build();
 
-    d.dispatch(&mut res, ());
+    d.dispatch(&mut res);
 }
 
 #[test]
@@ -95,12 +95,12 @@ fn dispatch_sequential() {
     let mut res = Resources::new();
     res.add(Res, ());
 
-    let mut d: Dispatcher<_> = DispatcherBuilder::new()
+    let mut d: Dispatcher = DispatcherBuilder::new()
         .add(DummySysMut, "a", &[])
         .add(DummySys, "b", &[])
         .build();
 
-    d.dispatch_seq(&mut res, ());
+    d.dispatch_seq(&mut res);
 }
 
 #[cfg(feature = "parallel")]
@@ -114,7 +114,7 @@ fn dispatch_async() {
         .add(DummySys, "b", &[])
         .build_async(res);
 
-    d.dispatch(());
+    d.dispatch();
 
     d.wait();
 }
@@ -130,7 +130,7 @@ fn dispatch_async_res() {
         .add(DummySys, "b", &[])
         .build_async(res);
 
-    d.dispatch(());
+    d.dispatch();
 
     let res = d.mut_res();
     res.add(Res, 2);


### PR DESCRIPTION
The context is not necessary because you can always just use a Resource.